### PR TITLE
feat(redwood): add nau learning header customization

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -28,7 +28,7 @@ ensureConfig([
 subscribe(APP_CONFIG_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
-    ENABLED_ORG_LOGO: !!process.env.ENABLED_ORG_LOGO,
+    ENABLE_ORG_LOGO: !!process.env.ENABLE_ORG_LOGO,
   }, 'Header additional config');
 });
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -28,6 +28,7 @@ ensureConfig([
 subscribe(APP_CONFIG_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
+    ENABLED_ORG_LOGO: !!process.env.ENABLED_ORG_LOGO,
   }, 'Header additional config');
 });
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -43,9 +43,9 @@ $white: #fff;
   .user-dropdown {
     .btn {
       height: 3rem;
-      // @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
-      //   padding: 0 0.5rem;
-      // }
+      @media (map-get($grid-breakpoints, "sm")) {
+        padding: 0 0.5rem;
+      }
     }
   }
 }

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -7,6 +7,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
 import messages from './messages';
+import getCourseLogoOrg from './data/api';
 
 const LinkedLogo = ({
   href,
@@ -26,9 +27,16 @@ LinkedLogo.propTypes = {
 };
 
 const LearningHeader = ({
-  courseOrg, courseNumber, courseTitle, intl, showUserDropdown,
+  courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
   const { authenticatedUser } = useContext(AppContext);
+  const [logoOrg, setLogoOrg] = useState(null);
+
+  useEffect(() => {
+    if (courseOrg) {
+      getCourseLogoOrg().then((logoOrgUrl) => { setLogoOrg(logoOrgUrl); });
+    }
+  }, []);
 
   const headerLogo = (
     <LinkedLogo
@@ -44,17 +52,25 @@ const LearningHeader = ({
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
-        <div className="flex-grow-1 course-title-lockup" style={{ lineHeight: 1 }}>
-          <span className="d-block small m-0">{courseOrg} {courseNumber}</span>
-          <span className="d-block m-0 font-weight-bold course-title">{courseTitle}</span>
+        <div className="flex-grow-1 course-title-lockup text-center" style={{ lineHeight: 1 }}>
+          {
+            (courseOrg && logoOrg)
+            && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '50px' }} />
+          }
+          <span
+            className="d-inline-block course-title font-weight-bold ml-3 overflow-hidden text-nowrap text-left w-25"
+            style={{ textOverflow: 'ellipsis' }}
+          >
+            {courseTitle}
+          </span>
         </div>
         {showUserDropdown && authenticatedUser && (
-        <AuthenticatedUserDropdown
-          username={authenticatedUser.username}
-        />
+          <AuthenticatedUserDropdown
+            username={authenticatedUser.username}
+          />
         )}
         {showUserDropdown && !authenticatedUser && (
-        <AnonymousUserMenu />
+          <AnonymousUserMenu />
         )}
       </div>
     </header>
@@ -63,7 +79,6 @@ const LearningHeader = ({
 
 LearningHeader.propTypes = {
   courseOrg: PropTypes.string,
-  courseNumber: PropTypes.string,
   courseTitle: PropTypes.string,
   intl: intlShape.isRequired,
   showUserDropdown: PropTypes.bool,
@@ -71,7 +86,6 @@ LearningHeader.propTypes = {
 
 LearningHeader.defaultProps = {
   courseOrg: null,
-  courseNumber: null,
   courseTitle: null,
   showUserDropdown: true,
 };

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -26,6 +26,10 @@ LinkedLogo.propTypes = {
   alt: PropTypes.string.isRequired,
 };
 
+// this feature flag is not included on the frontend-platform, we have to get it directly from ENV
+const enabledOrgLogo = process.env.ENABLED_ORG_LOGO || false;
+
+
 const LearningHeader = ({
   courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
@@ -52,17 +56,19 @@ const LearningHeader = ({
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
-        <div className="flex-grow-1 course-title-lockup text-center" style={{ lineHeight: 1 }}>
-          {
-            (courseOrg && logoOrg)
-            && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '50px' }} />
-          }
-          <span
-            className="d-inline-block course-title font-weight-bold ml-3 overflow-hidden text-nowrap text-left w-25"
-            style={{ textOverflow: 'ellipsis' }}
-          >
-            {courseTitle}
-          </span>
+        <div className="d-none d-md-block flex-grow-1 course-title-lockup">
+          <div className={`d-md-flex ${enabledOrgLogo && 'align-items-center justify-content-center'} w-100`}>
+            {enabledOrgLogo ? (
+              (courseOrg && logoOrg)
+              && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '45px' }} />
+            ) : null}
+            <span
+              className="d-inline-block course-title font-weight-semibold ml-3 text-truncate text-left w-25"
+              style={{ fontSize: '0.85rem' }}
+            >
+              {courseTitle}
+            </span>
+          </div>
         </div>
         {showUserDropdown && authenticatedUser && (
           <AuthenticatedUserDropdown

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -29,7 +29,6 @@ LinkedLogo.propTypes = {
 // this feature flag is not included on the frontend-platform, we have to get it directly from ENV
 const enabledOrgLogo = process.env.ENABLED_ORG_LOGO || false;
 
-
 const LearningHeader = ({
   courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
@@ -40,7 +39,7 @@ const LearningHeader = ({
     if (courseOrg) {
       getCourseLogoOrg().then((logoOrgUrl) => { setLogoOrg(logoOrgUrl); });
     }
-  }, []);
+  });
 
   const headerLogo = (
     <LinkedLogo

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -30,7 +30,7 @@ const LearningHeader = ({
 }) => {
   const { authenticatedUser } = useContext(AppContext);
   const [logoOrg, setLogoOrg] = useState(null);
-  const enabledOrgLogo = getConfig().ENABLED_ORG_LOGO || false;
+  const enableOrgLogo = getConfig().ENABLE_ORG_LOGO || false;
 
   useEffect(() => {
     if (courseOrg) {
@@ -53,8 +53,8 @@ const LearningHeader = ({
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
         <div className="d-none d-md-block flex-grow-1 course-title-lockup">
-          <div className={`d-md-flex ${enabledOrgLogo && 'align-items-center justify-content-center'} w-100`}>
-            {enabledOrgLogo ? (
+          <div className={`d-md-flex ${enableOrgLogo && 'align-items-center justify-content-center'} w-100`}>
+            {enableOrgLogo ? (
               (courseOrg && logoOrg)
               && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '45px' }} />
             ) : null}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -25,15 +25,12 @@ LinkedLogo.propTypes = {
   src: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
 };
-
-// this feature flag is not included on the frontend-platform, we have to get it directly from ENV
-const enabledOrgLogo = process.env.ENABLED_ORG_LOGO || false;
-
 const LearningHeader = ({
   courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
   const { authenticatedUser } = useContext(AppContext);
   const [logoOrg, setLogoOrg] = useState(null);
+  const enabledOrgLogo = getConfig().ENABLED_ORG_LOGO || false;
 
   useEffect(() => {
     if (courseOrg) {

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -27,7 +27,6 @@ describe('Header', () => {
     render(<Header {...courseData} />);
     waitFor(
       () => {
-
         expect(screen.getByAltText(`${courseData.courseOrg} logo`)).toHaveAttribute('src', 'logo-url');
         expect(screen.getByText(`${courseData.courseOrg}`)).toBeInTheDocument();
         expect(screen.getByText(courseData.courseTitle)).toBeInTheDocument();

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import {
-  authenticatedUser, initializeMockApp, render, screen,
+  authenticatedUser, initializeMockApp, render, screen, waitFor,
 } from '../setupTest';
 import { LearningHeader as Header } from '../index';
+
+jest.mock('./data/api', () => ({
+  getCourseLogoOrg: jest.fn().mockResolvedValue(Promise.resolve('logo-url')),
+}));
 
 describe('Header', () => {
   beforeAll(async () => {
@@ -18,12 +22,16 @@ describe('Header', () => {
   it('displays course data', () => {
     const courseData = {
       courseOrg: 'course-org',
-      courseNumber: 'course-number',
       courseTitle: 'course-title',
     };
     render(<Header {...courseData} />);
+    waitFor(
+      () => {
 
-    expect(screen.getByText(`${courseData.courseOrg} ${courseData.courseNumber}`)).toBeInTheDocument();
-    expect(screen.getByText(courseData.courseTitle)).toBeInTheDocument();
+        expect(screen.getByAltText(`${courseData.courseOrg} logo`)).toHaveAttribute('src', 'logo-url');
+        expect(screen.getByText(`${courseData.courseOrg}`)).toBeInTheDocument();
+        expect(screen.getByText(courseData.courseTitle)).toBeInTheDocument();
+      },
+    );
   });
 });

--- a/src/learning-header/_header.scss
+++ b/src/learning-header/_header.scss
@@ -1,0 +1,10 @@
+@import "../../node_modules/bootstrap/scss/bootstrap-grid";
+@import "../../node_modules/bootstrap/scss/mixins/breakpoints";
+
+.logo {
+    img {
+        @include media-breakpoint-down(sm) {
+            max-width: 85% !important;
+        }
+    }
+}

--- a/src/learning-header/data/api.js
+++ b/src/learning-header/data/api.js
@@ -1,0 +1,22 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+const getCourseLogoOrg = async () => {
+  try {
+    const orgId = window.location.pathname.match(/course-(.*?):([^+]+)/)[2];
+    const { data } = await getAuthenticatedHttpClient()
+      .get(
+        `${getConfig().LMS_BASE_URL}/api/organizations/v0/organizations/${orgId}/`,
+        { useCache: true },
+      );
+    return data.logo;
+  } catch (error) {
+    const { httpErrorStatus } = error && error.customAttributes;
+    if (httpErrorStatus === 404) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+export default getCourseLogoOrg;

--- a/src/learning-header/data/api.test.js
+++ b/src/learning-header/data/api.test.js
@@ -1,0 +1,59 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import getCourseLogoOrg from './api';
+import { initializeMockApp } from '../../setupTest';
+
+jest.mock('@edx/frontend-platform/auth');
+
+class CustomError extends Error {
+  constructor(httpErrorStatus) {
+    super();
+    this.customAttributes = {
+      httpErrorStatus,
+    };
+  }
+}
+
+describe('getCourseLogoOrg', () => {
+  beforeEach(async () => {
+    // We need to mock AuthService to implicitly use `getAuthenticatedHttpClient` within `AppContext.Provider`.
+    await initializeMockApp();
+    delete window.location;
+    getAuthenticatedHttpClient.mockReset();
+  });
+
+  it('should return the organization logo when the URL is valid', async () => {
+    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
+    getAuthenticatedHttpClient.mockReturnValue({
+      get: async () => Promise.resolve({
+        data: {
+          logo: 'https://example.com/logo.svg',
+        },
+      }),
+    });
+    const logoOrg = await getCourseLogoOrg();
+    expect(logoOrg).toBe('https://example.com/logo.svg');
+  });
+
+  it('should return null when the organization logo is not found', async () => {
+    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Nonexistent_Course/home`);
+    getAuthenticatedHttpClient.mockReturnValue({
+      get: async () => {
+        throw new CustomError(404);
+      },
+    });
+    const logoOrg = await getCourseLogoOrg();
+    expect(logoOrg).toBeNull();
+  });
+
+  it('should throw an error when an unexpected error occurs', async () => {
+    const customError = new CustomError(500);
+    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
+    getAuthenticatedHttpClient.mockReturnValue({
+      get: async () => {
+        throw customError;
+      },
+    });
+    await expect(getCourseLogoOrg()).rejects.toThrow(customError);
+  });
+});


### PR DESCRIPTION
This PR migrates the custom NAU header changes to the Redwood version. 

![image](https://github.com/fccn/frontend-component-header-nau/assets/66016493/f94b33ea-48fc-44da-a70e-d4afda11d217)

**How to test**

1. Create a tutor redwood environment.
2.  Inside your environment clone the learning MFE and mount it with `tutor mounts add ./frontend-app-learning`.
3. Inside the learning MFE, clone the header repository with the current branch (remember to run `npm install` for both, the learning app and the header).
4. Create the `module.config.js` file and add the following configuration.
```javascript
module.exports = {
  localModules: [
    { moduleName: '@edx/frontend-component-header/dist', dir: './frontend-component-header-nau', dist: 'src' },
    { moduleName: '@edx/frontend-component-header', dir: './frontend-component-header-nau', dist: 'src' },
  ],
};
```
3. Run the command `tutor images build learning-dev`.
4. Start your environment `tutor dev start`.
5. Create a course and configure the organization info inside the LMS admin.
6. Open the courseware and check you can see the changes.