### PR TITLE
fix: github actions release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release CI
 on:
   push:
     branches:
-    - master
-    - alpha
+    - nau/*.master
+
 jobs:
   release:
     name: Release
@@ -33,10 +33,15 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Build
       run: npm run build
-    - name: Release
-      uses: cycjimmy/semantic-release-action@v3
+    - name: Release to npmjs
+      uses: pascalgn/npm-publish-action@1.3.9
       with:
-        semantic_version: 16
+        tag_name: "v%s"
+        tag_message: "v%s"
+        commit_pattern: "^chore(release): (\\S+)"
+        workspace: "."
+        publish_command: "npm"
+        publish_args: "--non-interactive"
       env:
         GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@edx/frontend-component-header",
-  "version": "1.0.0-semantically-released",
-  "description": "The standard header for Open edX",
+  "name": "@nauedu/frontend-component-header",
+  "version": "18.0.0",
+  "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {
     "access": "public"
@@ -24,14 +24,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openedx/frontend-component-header.git"
+    "url": "git+https://github.com/fccn/frontend-component-header-nau.git"
   },
   "author": "edX",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/openedx/frontend-component-header/issues"
+    "url": "https://github.com/fccn/frontend-component-header-nau/issues"
   },
-  "homepage": "https://github.com/openedx/frontend-component-header#readme",
+  "homepage": "https://github.com/fccn/frontend-component-header-nau#readme",
   "devDependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "^1.1.1",


### PR DESCRIPTION
- remove the semantic release code and replace it with repo tagging.
- when the `package.json` version is updated, a new npm package is generated.

My observation is that we don't need the confusion that semantic-release creates. It's better to be more descriptive about our releases. As is, the idea is to have the major release number reflect the openedx version.

When we need to update, we just change `package.json` and let github actions run normally.

Adapted directly from https://github.com/pascalgn/npm-publish-action