### PR TITLE
fix: display org logo when is enable

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -3,7 +3,7 @@ import Responsive from 'react-responsive';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
-  APP_CONFIG_INITIALIZED,
+  APP_PUBSUB_INITIALIZED,
   ensureConfig,
   mergeConfig,
   getConfig,
@@ -25,7 +25,7 @@ ensureConfig([
   'ORDER_HISTORY_URL',
 ], 'Header component');
 
-subscribe(APP_CONFIG_INITIALIZED, () => {
+subscribe(APP_PUBSUB_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
     ENABLE_ORG_LOGO: !!process.env.ENABLE_ORG_LOGO,

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -30,13 +30,13 @@ const LearningHeader = ({
 }) => {
   const { authenticatedUser } = useContext(AppContext);
   const [logoOrg, setLogoOrg] = useState(null);
-  const enableOrgLogo = getConfig().ENABLE_ORG_LOGO || false;
+  const enableOrgLogo = getConfig().ENABLE_ORG_LOGO;
 
   useEffect(() => {
-    if (courseOrg) {
+    if (courseOrg && enableOrgLogo) {
       getCourseLogoOrg().then((logoOrgUrl) => { setLogoOrg(logoOrgUrl); });
     }
-  });
+  }, [courseOrg, enableOrgLogo]);
 
   const headerLogo = (
     <LinkedLogo


### PR DESCRIPTION
This PR fix the override that was happening and display the organization loge once the feature is enable. 

![image](https://github.com/user-attachments/assets/2ef4f786-579c-4139-b272-1b1438fbf8bd)

Also, add dependencies in the useEffect to avoid unnecessary recalls to the API