### PR TITLE
feat: add header selector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,9 @@ Environment Variables
 * ``AUTHN_MINIMAL_HEADER`` - A boolean flag which hides the main menu, user menu, and logged-out
   menu items when truthy.  This is intended to be used in micro-frontends like
   frontend-app-authentication in which these menus are considered distractions from the user's task.
+* ``ENABLE_HEADER_LANG_SELECTOR`` - A boolean to enable the language selector in the header component.
+* ``SITE_SUPPORTED_LANGUAGES`` - A list with all the languages to display in the selector.
+
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Environment Variables
   frontend-app-authentication in which these menus are considered distractions from the user's task.
 * ``ENABLE_HEADER_LANG_SELECTOR`` - A boolean to enable the language selector in the header component.
 * ``SITE_SUPPORTED_LANGUAGES`` - A list with all the languages to display in the selector.
+* ``LOGO_URL_MOBILE`` - The URL of the site's logo for mobile. This logo is displayed in the header.
 
 
 Installation

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -154,7 +154,7 @@ class DesktopHeader extends React.Component {
             {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
               <div className="mx-2">
                 <LanguageSelector
-                  options={getConfig().SITE_SUPPORTED_LENGUAGES}
+                  options={getConfig().SITE_SUPPORTED_LANGUAGES}
                   authenticatedUser={getAuthenticatedUser()}
                 />
               </div>

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 // Local Components
 import { Menu, MenuTrigger, MenuContent } from './Menu';
@@ -13,6 +14,7 @@ import messages from './Header.messages';
 
 // Assets
 import { CaretIcon } from './Icons';
+import LanguageSelector from './LanguageSelector';
 
 class DesktopHeader extends React.Component {
   constructor(props) { // eslint-disable-line no-useless-constructor
@@ -145,13 +147,21 @@ class DesktopHeader extends React.Component {
             {logoDestination === null ? <Logo className="logo" src={logo} alt={logoAltText} /> : <LinkedLogo className="logo" {...logoProps} />}
             <nav
               aria-label={intl.formatMessage(messages['header.label.main.nav'])}
-              className="nav main-nav"
+              className="nav main-nav mr-auto"
             >
               {this.renderMainMenu()}
             </nav>
+            {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
+              <div className="mx-2">
+                <LanguageSelector
+                  options={getConfig().SITE_SUPPORTED_LENGUAGES}
+                  authenticatedUser={getAuthenticatedUser()}
+                />
+              </div>
+            )}
             <nav
               aria-label={intl.formatMessage(messages['header.label.secondary.nav'])}
-              className="nav secondary-menu-container align-items-center ml-auto"
+              className="nav secondary-menu-container align-items-center"
             >
               {loggedIn
                 ? (

--- a/src/LanguageSelector/data/api.js
+++ b/src/LanguageSelector/data/api.js
@@ -1,0 +1,32 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { convertKeyNames, snakeCaseObject } from '@edx/frontend-platform/utils';
+
+export async function patchPreferences(username, params) {
+  let processedParams = snakeCaseObject(params);
+  processedParams = convertKeyNames(processedParams, {
+    pref_lang: 'pref-lang',
+  });
+
+  await getAuthenticatedHttpClient()
+    .patch(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`, processedParams, {
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+    });
+
+  return params;
+}
+
+export async function postSetLang(code) {
+  const formData = new FormData();
+  const requestConfig = {
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  };
+  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
+  formData.append('language', code);
+
+  await getAuthenticatedHttpClient()
+    .post(url, formData, requestConfig);
+}

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGlobe } from '@fortawesome/free-solid-svg-icons';
 import { publish } from '@edx/frontend-platform';
 import {
   getLocale, injectIntl, intlShape, FormattedMessage, LOCALE_CHANGED, handleRtl,
 } from '@edx/frontend-platform/i18n';
+import { Dropdown } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { patchPreferences, postSetLang } from './data/api';
@@ -24,10 +27,8 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 const LanguageSelector = ({
   intl, options, authenticatedUser, ...props
 }) => {
-  const handleSubmit = (e) => {
-    e.preventDefault();
+  const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
-    const languageCode = e.target.elements['site-header-language-select'].value;
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
 
     if (previousSiteLanguage !== languageCode) {
@@ -36,37 +37,18 @@ const LanguageSelector = ({
   };
 
   return (
-    <form
-      className="form-inline"
-      onSubmit={handleSubmit}
-      {...props}
-    >
-      <div className="form-group d-wrap">
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-        <label htmlFor="site-header-language-select" className="d-inline-block m-0 small">
-          <FormattedMessage
-            id="footer.languageForm.select.label"
-            defaultMessage="Choose Language"
-            description="The label for the laguage select part of the language selection form."
-          />
-        </label>
-        <select
-          id="site-header-language-select"
-          className="form-control-sm mx-2"
-          name="site-header-language-select"
-          defaultValue={intl.locale}
-        >
-          {options.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
-        </select>
-        <button data-testid="site-header-submit-btn" className="btn btn-outline-primary btn-sm" type="submit">
-          <FormattedMessage
-            id="footer.languageForm.submit.label"
-            defaultMessage="Apply"
-            description="The label for button to submit the language selection form."
-          />
-        </button>
-      </div>
-    </form>
+    <Dropdown className="language-selector" >
+      <Dropdown.Toggle variant="outline-primary">
+        <FontAwesomeIcon icon={faGlobe} />
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+      {options.map(({ value, label }) => (
+        <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
+          {label}
+        </Dropdown.Item>
+      ))}
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
 

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -25,8 +25,14 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 };
 
 const LanguageSelector = ({
-  intl, options, authenticatedUser, ...props
+  intl, options, authenticatedUser, compact, ...props
 }) => {
+
+  const languageLabel = (languageCode) => {
+    const option = options.find( ({ value, label }) => value === languageCode )
+    return option ? option.label : null
+  }
+
   const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
@@ -34,21 +40,43 @@ const LanguageSelector = ({
     if (previousSiteLanguage !== languageCode) {
       onLanguageSelected(authenticatedUser?.username, languageCode);
     }
+
+    event.target.parentElement.parentElement.querySelector(".languageLabel").innerHTML = languageLabel(languageCode);
   };
 
+  const currentLangLabel = languageLabel(intl.locale)
+  const showLabel = !Boolean(compact || false);
+
   return (
-    <Dropdown className="language-selector" >
-      <Dropdown.Toggle variant="outline-primary">
-        <FontAwesomeIcon icon={faGlobe} />
-      </Dropdown.Toggle>
-      <Dropdown.Menu>
-      {options.map(({ value, label }) => (
-        <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
-          {label}
-        </Dropdown.Item>
-      ))}
-      </Dropdown.Menu>
-    </Dropdown>
+    <>
+      <Dropdown className="language-selector">
+        <Dropdown.Toggle variant="outline-primary">
+          <FontAwesomeIcon icon={faGlobe} />
+          {showLabel && (
+            currentLangLabel ? (
+              <span class="pl-1 languageLabel">
+                {currentLangLabel}
+              </span>
+            ) : (
+              <span class="pl-1">
+                <FormattedMessage
+                  id="footer.languageForm.select.label"
+                  defaultMessage="Choose Language"
+                  description="The label for the laguage select part of the language selection form."
+                />
+              </span>
+            )
+          )}
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+        {options.map(({ value, label }) => (
+          <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
+            {label}
+          </Dropdown.Item>
+        ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
   );
 };
 
@@ -57,6 +85,7 @@ LanguageSelector.propTypes = {
     username: PropTypes.string,
   }).isRequired,
   intl: intlShape.isRequired,
+  compact: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string,
     label: PropTypes.string,

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { publish } from '@edx/frontend-platform';
+import {
+  getLocale, injectIntl, intlShape, FormattedMessage, LOCALE_CHANGED, handleRtl,
+} from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { patchPreferences, postSetLang } from './data/api';
+
+const onLanguageSelected = async (username, selectedLanguageCode) => {
+  try {
+    if (username) {
+      await patchPreferences(username, { prefLang: selectedLanguageCode });
+      await postSetLang(selectedLanguageCode);
+    }
+    publish(LOCALE_CHANGED, getLocale());
+    handleRtl();
+  } catch (error) {
+    logError(error);
+  }
+};
+
+const LanguageSelector = ({
+  intl, options, authenticatedUser, ...props
+}) => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const previousSiteLanguage = getLocale();
+    const languageCode = e.target.elements['site-header-language-select'].value;
+    console.debug(previousSiteLanguage, languageCode, authenticatedUser);
+
+    if (previousSiteLanguage !== languageCode) {
+      onLanguageSelected(authenticatedUser?.username, languageCode);
+    }
+  };
+
+  return (
+    <form
+      className="form-inline"
+      onSubmit={handleSubmit}
+      {...props}
+    >
+      <div className="form-group d-wrap">
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label htmlFor="site-header-language-select" className="d-inline-block m-0 small">
+          <FormattedMessage
+            id="footer.languageForm.select.label"
+            defaultMessage="Choose Language"
+            description="The label for the laguage select part of the language selection form."
+          />
+        </label>
+        <select
+          id="site-header-language-select"
+          className="form-control-sm mx-2"
+          name="site-header-language-select"
+          defaultValue={intl.locale}
+        >
+          {options.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
+        </select>
+        <button data-testid="site-header-submit-btn" className="btn btn-outline-primary btn-sm" type="submit">
+          <FormattedMessage
+            id="footer.languageForm.submit.label"
+            defaultMessage="Apply"
+            description="The label for button to submit the language selection form."
+          />
+        </button>
+      </div>
+    </form>
+  );
+};
+
+LanguageSelector.propTypes = {
+  authenticatedUser: PropTypes.shape({
+    username: PropTypes.string,
+  }).isRequired,
+  intl: intlShape.isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string,
+    label: PropTypes.string,
+  })).isRequired,
+};
+
+export default injectIntl(LanguageSelector);

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -25,58 +25,57 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 };
 
 const LanguageSelector = ({
-  intl, options, authenticatedUser, compact, ...props
+  intl, options, authenticatedUser, compact,
 }) => {
-
   const languageLabel = (languageCode) => {
-    const option = options.find( ({ value, label }) => value === languageCode )
-    return option ? option.label : null
-  }
+    const option = options.find(({ value }) => value === languageCode);
+    return option ? option.label : null;
+  };
 
   const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
+    /* eslint-disable no-console */
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
 
     if (previousSiteLanguage !== languageCode) {
       onLanguageSelected(authenticatedUser?.username, languageCode);
     }
 
-    event.target.parentElement.parentElement.querySelector(".languageLabel").innerHTML = languageLabel(languageCode);
+    const languageLabelElement = event.target.parentElement.parentElement.querySelector('.languageLabel');
+    languageLabelElement.innerHTML = languageLabel(languageCode);
   };
 
-  const currentLangLabel = languageLabel(intl.locale)
-  const showLabel = !Boolean(compact || false);
+  const currentLangLabel = languageLabel(intl.locale);
+  const showLabel = !(compact || false);
 
   return (
-    <>
-      <Dropdown className="language-selector">
-        <Dropdown.Toggle variant="outline-primary">
-          <FontAwesomeIcon icon={faGlobe} />
-          {showLabel && (
-            currentLangLabel ? (
-              <span class="pl-1 languageLabel">
-                {currentLangLabel}
-              </span>
-            ) : (
-              <span class="pl-1">
-                <FormattedMessage
-                  id="footer.languageForm.select.label"
-                  defaultMessage="Choose Language"
-                  description="The label for the laguage select part of the language selection form."
-                />
-              </span>
-            )
-          )}
-        </Dropdown.Toggle>
-        <Dropdown.Menu>
+    <Dropdown className="language-selector">
+      <Dropdown.Toggle variant="outline-primary">
+        <FontAwesomeIcon icon={faGlobe} />
+        {showLabel && (
+          currentLangLabel ? (
+            <span className="pl-1 languageLabel">
+              {currentLangLabel}
+            </span>
+          ) : (
+            <span className="pl-1">
+              <FormattedMessage
+                id="footer.languageForm.select.label"
+                defaultMessage="Choose Language"
+                description="The label for the laguage select part of the language selection form."
+              />
+            </span>
+          )
+        )}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
         {options.map(({ value, label }) => (
           <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
             {label}
           </Dropdown.Item>
         ))}
-        </Dropdown.Menu>
-      </Dropdown>
-    </>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
 
@@ -90,6 +89,10 @@ LanguageSelector.propTypes = {
     value: PropTypes.string,
     label: PropTypes.string,
   })).isRequired,
+};
+
+LanguageSelector.defaultProps = {
+  compact: false,
 };
 
 export default injectIntl(LanguageSelector);

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -28,7 +28,7 @@ exports[`<Header /> renders correctly for anonymous desktop 1`] = `
       </a>
       <nav
         aria-label="Main"
-        className="nav main-nav"
+        className="nav main-nav mr-auto"
       >
         <a
           className="nav-link"
@@ -39,7 +39,7 @@ exports[`<Header /> renders correctly for anonymous desktop 1`] = `
       </nav>
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="nav secondary-menu-container align-items-center"
       >
         <a
           className="btn mr-2 btn-link"
@@ -224,7 +224,7 @@ exports[`<Header /> renders correctly for authenticated desktop 1`] = `
       </a>
       <nav
         aria-label="Main"
-        className="nav main-nav"
+        className="nav main-nav mr-auto"
       >
         <a
           className="nav-link"
@@ -235,7 +235,7 @@ exports[`<Header /> renders correctly for authenticated desktop 1`] = `
       </nav>
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="nav secondary-menu-container align-items-center"
       >
         <div
           className="menu null"

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -70,7 +70,7 @@ const LearningHeader = ({
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-none d-md-inline-flex">
             <LanguageSelector
-              options={getConfig().SITE_SUPPORTED_LENGUAGES}
+              options={JSON.parse(getConfig().SITE_SUPPORTED_LENGUAGES)}
               authenticatedUser={authenticatedUser}
             />
           </div>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -8,6 +8,7 @@ import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
 import messages from './messages';
 import getCourseLogoOrg from './data/api';
+import LanguageSelector from '../LanguageSelector';
 
 const LinkedLogo = ({
   href,
@@ -66,6 +67,14 @@ const LearningHeader = ({
             </span>
           </div>
         </div>
+        {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
+          <div className="mx-2 d-none d-md-inline-flex">
+            <LanguageSelector
+              options={getConfig().SITE_SUPPORTED_LENGUAGES}
+              authenticatedUser={authenticatedUser}
+            />
+          </div>
+        )}
         {showUserDropdown && authenticatedUser && (
           <AuthenticatedUserDropdown
             username={authenticatedUser.username}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
+import Responsive from 'react-responsive';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -40,12 +41,24 @@ const LearningHeader = ({
   });
 
   const headerLogo = (
-    <LinkedLogo
-      className="logo"
-      href={`${getConfig().LMS_BASE_URL}/dashboard`}
-      src={getConfig().LOGO_URL}
-      alt={getConfig().SITE_NAME}
-    />
+    <>
+      <Responsive maxWidth={769}>
+        <LinkedLogo
+          className="logo"
+          href={`${getConfig().LMS_BASE_URL}/dashboard`}
+          src={getConfig().LOGO_URL_MOBILE || getConfig().LOGO_URL}
+          alt={getConfig().SITE_NAME}
+        />
+      </Responsive>
+      <Responsive minWidth={769}>
+        <LinkedLogo
+            className="logo"
+            href={`${getConfig().LMS_BASE_URL}/dashboard`}
+            src={getConfig().LOGO_URL}
+            alt={getConfig().SITE_NAME}
+          />
+      </Responsive>
+    </>
   );
 
   return (

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -82,10 +82,20 @@ const LearningHeader = ({
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-md-inline-flex">
-            <LanguageSelector
-              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-              authenticatedUser={authenticatedUser}
-            />
+            <Responsive maxWidth={1000}>
+              <LanguageSelector
+                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                compact={true}
+                authenticatedUser={authenticatedUser}
+              />
+            </Responsive>
+            <Responsive minWidth={1000}>
+              <LanguageSelector
+                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                compact={false}
+                authenticatedUser={authenticatedUser}
+              />
+            </Responsive>
           </div>
         )}
         {showUserDropdown && authenticatedUser && (

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -68,7 +68,7 @@ const LearningHeader = ({
           </div>
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
-          <div className="mx-2 d-none d-md-inline-flex">
+          <div className="mx-2 d-md-inline-flex">
             <LanguageSelector
               options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
               authenticatedUser={authenticatedUser}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -52,11 +52,11 @@ const LearningHeader = ({
       </Responsive>
       <Responsive minWidth={769}>
         <LinkedLogo
-            className="logo"
-            href={`${getConfig().LMS_BASE_URL}/dashboard`}
-            src={getConfig().LOGO_URL}
-            alt={getConfig().SITE_NAME}
-          />
+          className="logo"
+          href={`${getConfig().LMS_BASE_URL}/dashboard`}
+          src={getConfig().LOGO_URL}
+          alt={getConfig().SITE_NAME}
+        />
       </Responsive>
     </>
   );
@@ -85,7 +85,7 @@ const LearningHeader = ({
             <Responsive maxWidth={1000}>
               <LanguageSelector
                 options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                compact={true}
+                compact
                 authenticatedUser={authenticatedUser}
               />
             </Responsive>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -70,7 +70,7 @@ const LearningHeader = ({
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-none d-md-inline-flex">
             <LanguageSelector
-              options={JSON.parse(getConfig().SITE_SUPPORTED_LENGUAGES)}
+              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
               authenticatedUser={authenticatedUser}
             />
           </div>


### PR DESCRIPTION
This PR modifies the language selector behavior updating the user preference and changing the language on the fly.

**How to test**
- Use the current PR in the test instance
- Be sure the app has the translations in the supported languages.
- Add ``ENABLE_HEADER_LANG_SELECTOR``  and ``SITE_SUPPORTED_LENGUAGES``  into the instance settings
- Test the selector


https://github.com/user-attachments/assets/6d42a607-69ca-4cd1-85c1-d22b82ed6c25

