### PR TITLE
feat: added Gamification Settings link for Studio header

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -20,3 +20,4 @@ LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
 LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
 LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg
 FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
+GAMMA_SETTINGS_URL=http://0.0.0.0:9700/gamma/badges

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -38,6 +38,7 @@ process.env.LOGO_URL = 'https://edx-cdn.org/v3/default/logo.svg';
 process.env.LOGO_TRADEMARK_URL = 'https://edx-cdn.org/v3/default/logo-trademark.svg';
 process.env.LOGO_WHITE_URL = 'https://edx-cdn.org/v3/default/logo-white.svg';
 process.env.FAVICON_URL = 'https://edx-cdn.org/v3/default/favicon.ico';
+process.env.GAMMA_SETTINGS_URL = 'http://0.0.0.0:9700/gamma/badges';
 
 class MockLoggingService {
   logInfo = jest.fn();
@@ -66,6 +67,7 @@ export function initializeMockApp() {
     CSRF_TOKEN_API_PATH: process.env.CSRF_TOKEN_API_PATH || null,
     LOGO_URL: process.env.LOGO_URL || null,
     SITE_NAME: process.env.SITE_NAME || null,
+    GAMMA_SETTINGS_URL: process.env.GAMMA_SETTINGS_URL || null,
 
     authenticatedUser: {
       userId: 'abc123',

--- a/src/studio-header/HeaderBody.jsx
+++ b/src/studio-header/HeaderBody.jsx
@@ -37,6 +37,7 @@ const HeaderBody = ({
   mainMenuDropdowns,
   outlineLink,
   searchButtonAction,
+  gammaSettingsUrl,
 }) => {
   const intl = useIntl();
 
@@ -121,6 +122,7 @@ const HeaderBody = ({
               logoutUrl,
               authenticatedUserAvatar,
               isAdmin,
+              gammaSettingsUrl,
             }}
           />
         </Nav>
@@ -155,6 +157,7 @@ HeaderBody.propTypes = {
   })),
   outlineLink: PropTypes.string,
   searchButtonAction: PropTypes.func,
+  gammaSettingsUrl: PropTypes.string,
 };
 
 HeaderBody.defaultProps = {
@@ -174,6 +177,7 @@ HeaderBody.defaultProps = {
   mainMenuDropdowns: [],
   outlineLink: null,
   searchButtonAction: null,
+  gammaSettingsUrl: null,
 };
 
 export default HeaderBody;

--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -34,6 +34,7 @@ const StudioHeader = ({
     mainMenuDropdowns,
     outlineLink,
     searchButtonAction,
+    gammaSettingsUrl: config.GAMMA_SETTINGS_URL,
   };
 
   return (

--- a/src/studio-header/StudioHeader.test.jsx
+++ b/src/studio-header/StudioHeader.test.jsx
@@ -34,6 +34,7 @@ const RootWrapper = ({
       SITE_NAME: process.env.SITE_NAME,
       STUDIO_BASE_URL: process.env.STUDIO_BASE_URL,
       LOGIN_URL: process.env.LOGIN_URL,
+      GAMMA_SETTINGS_URL: process.env.GAMMA_SETTINGS_URL,
     },
   }), []);
   const responsiveContextValue = useMemo(() => ({ width: screenWidth }), []);
@@ -70,6 +71,7 @@ const props = {
   ],
   outlineLink: 'tEsTLInK',
   searchButtonAction: null,
+  gammaSettingsUrl: null,
 };
 
 describe('Header', () => {
@@ -119,6 +121,27 @@ describe('Header', () => {
       const maintenanceButton = queryByText(messages['header.user.menu.maintenance'].defaultMessage);
 
       expect(maintenanceButton).toBeNull();
+    });
+
+    it('gamification settings link should be in user menu', async () => {
+      currentUser = { ...authenticatedUser };
+      const { getAllByRole, queryByText } = render(<RootWrapper {...props} />);
+      const userMenu = getAllByRole('button')[1];
+      await waitFor(() => fireEvent.click(userMenu));
+      const gamificationSettingsButton = queryByText(messages['header.user.menu.gamification-settings'].defaultMessage);
+
+      expect(gamificationSettingsButton).toBeVisible();
+      expect(gamificationSettingsButton.href).toBe(process.env.GAMMA_SETTINGS_URL);
+    });
+
+    it('gamification settings link should not be in user menu', async () => {
+      currentUser = { ...authenticatedUser, administrator: false };
+      const { getAllByRole, queryByText } = render(<RootWrapper {...props} />);
+      const userMenu = getAllByRole('button')[1];
+      await waitFor(() => fireEvent.click(userMenu));
+      const gamificationSettingsButton = queryByText(messages['header.user.menu.gamification-settings'].defaultMessage);
+
+      expect(gamificationSettingsButton).toBeNull();
     });
 
     it('user menu should use avatar icon', async () => {

--- a/src/studio-header/UserMenu.jsx
+++ b/src/studio-header/UserMenu.jsx
@@ -14,6 +14,7 @@ const UserMenu = ({
   authenticatedUserAvatar,
   isMobile,
   isAdmin,
+  gammaSettingsUrl,
   // injected
   intl,
 }) => {
@@ -43,6 +44,7 @@ const UserMenu = ({
         logoutUrl,
         intl,
         isAdmin,
+        gammaSettingsUrl,
       })}
     />
   );
@@ -55,6 +57,7 @@ UserMenu.propTypes = {
   authenticatedUserAvatar: PropTypes.string,
   isMobile: PropTypes.bool,
   isAdmin: PropTypes.bool,
+  gammaSettingsUrl: PropTypes.string,
   // injected
   intl: intlShape.isRequired,
 };
@@ -64,6 +67,7 @@ UserMenu.defaultProps = {
   isAdmin: false,
   authenticatedUserAvatar: null,
   username: null,
+  gammaSettingsUrl: null,
 };
 
 export default injectIntl(UserMenu);

--- a/src/studio-header/messages.js
+++ b/src/studio-header/messages.js
@@ -11,6 +11,11 @@ const messages = defineMessages({
     defaultMessage: 'Maintenance',
     description: 'Link to the Studio maintenance page',
   },
+  'header.user.menu.gamification-settings': {
+    id: 'header.user.menu.gamification-settings',
+    defaultMessage: 'Gamification Settings',
+    description: 'Link to the Studio gamification settings page',
+  },
   'header.user.menu.logout': {
     id: 'header.user.menu.logout',
     defaultMessage: 'Logout',

--- a/src/studio-header/utils.js
+++ b/src/studio-header/utils.js
@@ -5,6 +5,7 @@ const getUserMenuItems = ({
   logoutUrl,
   intl,
   isAdmin,
+  gammaSettingsUrl,
 }) => {
   let items = [
     {
@@ -23,11 +24,20 @@ const getUserMenuItems = ({
       }, {
         href: `${studioBaseUrl}/maintenance`,
         title: intl.formatMessage(messages['header.user.menu.maintenance']),
-      }, {
-        href: `${logoutUrl}`,
-        title: intl.formatMessage(messages['header.user.menu.logout']),
       },
     ];
+
+    if (gammaSettingsUrl) {
+      items.push({
+        href: `${gammaSettingsUrl}`,
+        title: intl.formatMessage(messages['header.user.menu.gamification-settings']),
+      });
+    }
+
+    items.push({
+      href: `${logoutUrl}`,
+      title: intl.formatMessage(messages['header.user.menu.logout']),
+    });
   }
 
   return items;


### PR DESCRIPTION
## Description

Added gamification settings link for Studio header

## Testing instructions

1. Open the Django admin (Site configurations) and add `GAMMA_SETTINGS_URL` with the appropriate link to the gamma settings page.
2. Open any Studio page.
3. Ensure you are logged in as an administrator.
4. Open the user dropdown.
5. Ensure the link to `GAMMA_SETTINGS_URL` works correctly.

## Other information

https://github.com/user-attachments/assets/88f88d89-2ac4-4e9a-8df3-3a9c8586891a

**Config example:**
```
{
    "MFE_CONFIG_OVERRIDES": {
        "course-authoring": {
            "GAMMA_SETTINGS_URL": "http://0.0.0.0:9700/gamma/badges"
        }
    }
}
```