### PR TITLE
feat: use the compact version of language select

### DIFF
--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -81,20 +81,11 @@ const LearningHeader = ({
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-md-inline-flex">
-            <Responsive maxWidth={1200}>
-              <LanguageSelector
-                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                compact
-                authenticatedUser={authenticatedUser}
-              />
-            </Responsive>
-            <Responsive minWidth={1200}>
-              <LanguageSelector
-                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                compact={false}
-                authenticatedUser={authenticatedUser}
-              />
-            </Responsive>
+            <LanguageSelector
+              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+              compact
+              authenticatedUser={authenticatedUser}
+            />
           </div>
         )}
         {showUserDropdown && authenticatedUser && (


### PR DESCRIPTION
Always use the compacted version of the language selection on the header. When Richie changes the language cookie to be 'pt' the MFEs show any language on the header, so it is kind of strange. So now showing the language name on the header is better, it hides the problem and give us more space on the header, but still showning an easy way the learner to change it.

![image](https://github.com/user-attachments/assets/74c927d5-78b7-4d1d-a89f-f8ab8ac211a4)
