### PR TITLE
DRAFT: added Gamma Leaderboard and Dashboard links

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -16,6 +16,8 @@ import MobileHeader from './MobileHeader';
 
 import messages from './Header.messages';
 
+const showGamification = process.env.ENABLE_RG_GAMIFICATION ? process.env.ENABLE_RG_GAMIFICATION.toLowerCase() === 'true' : null;
+
 ensureConfig([
   'LMS_BASE_URL',
   'LOGOUT_URL',
@@ -59,6 +61,20 @@ const Header = ({
       content: intl.formatMessage(messages['header.links.courses']),
     },
   ];
+
+  const gamificationItems = [
+    {
+      type: 'item',
+      href: `${config.LMS_BASE_URL}/gamma_dashboard/dashboard`,
+      content: intl.formatMessage(messages['header.menu.performance.label']),
+    },
+    {
+      type: 'item',
+      href: `${config.LMS_BASE_URL}/gamma_dashboard/leaderboard`,
+      content: intl.formatMessage(messages['header.menu.leaderboard.label']),
+    },
+  ];
+
   const defaultUserMenu = authenticatedUser === null ? [] : [{
     heading: '',
     items: [
@@ -67,6 +83,8 @@ const Header = ({
         href: `${config.LMS_BASE_URL}/dashboard`,
         content: intl.formatMessage(messages['header.user.menu.dashboard']),
       },
+      // Add gamification items here if enabled
+      ...(showGamification ? gamificationItems : []),
       {
         type: 'item',
         href: `${config.ACCOUNT_PROFILE_URL}/u/${authenticatedUser.username}`,

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -9,6 +9,8 @@ import { Dropdown } from '@openedx/paragon';
 
 import messages from './messages';
 
+const showGamification = process.env.ENABLE_RG_GAMIFICATION ? process.env.ENABLE_RG_GAMIFICATION.toLowerCase() === 'true' : null;
+
 const AuthenticatedUserDropdown = ({ intl, username }) => {
   const dashboardMenuItem = (
     <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/dashboard`}>
@@ -28,6 +30,16 @@ const AuthenticatedUserDropdown = ({ intl, username }) => {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
           {dashboardMenuItem}
+          {showGamification && (
+            <>
+              <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/gamma_dashboard/dashboard`}>
+                {intl.formatMessage(messages.performance)}
+              </Dropdown.Item>
+              <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/gamma_dashboard/leaderboard`}>
+                {intl.formatMessage(messages.leaderboard)}
+              </Dropdown.Item>
+            </>
+          )}
           <Dropdown.Item href={`${getConfig().ACCOUNT_PROFILE_URL}/u/${username}`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>

--- a/src/learning-header/messages.js
+++ b/src/learning-header/messages.js
@@ -36,6 +36,16 @@ const messages = defineMessages({
     defaultMessage: 'Sign Out',
     description: 'The label for the user menu Sign Out action.',
   },
+  performance: {
+    id: 'header.menu.performance.label',
+    defaultMessage: 'Performance',
+    description: 'The label for the user menu Gamma dashboard action.',
+  },
+  leaderboard: {
+    id: 'header.menu.leaderboard.label',
+    defaultMessage: 'Leaderboard',
+    description: 'The label for the user menu Gamma leaderboard action.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Added gamification links for LMS MFE Header

## Testing instructions

1. Enable `ENABLE_RG_GAMIFICATION` feature flag.
2. Enable platform Leaderboard page (Django admin waffle flag - `rgg.show_gamma_leaderboard `).
3. Open some LMS page.
4. Ensure the Leaderboard and Dashboard links are displayed in the user dropdown menu in the header.

![image](https://github.com/user-attachments/assets/f13da2e2-cb89-47ab-a2d9-32cbed792932)