### PR TITLE
fix: render LearningHelpSlot in LearningHeader to support plugin injection

### DIFF
--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -8,6 +8,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
 import LogoSlot from '../plugin-slots/LogoSlot';
+import LearningHelpSlot from '../plugin-slots/LearningHelpSlot';
 import messages from './messages';
 import getCourseLogoOrg from './data/api';
 import LanguageSelector from '../LanguageSelector';
@@ -98,9 +99,12 @@ const LearningHeader = ({
             </div>
           )}
           {showUserDropdown && authenticatedUser && (
-            <AuthenticatedUserDropdown
-              username={authenticatedUser.username}
-            />
+            <>
+              <LearningHelpSlot />
+              <AuthenticatedUserDropdown
+                username={authenticatedUser.username}
+              />
+            </>
           )}
           {showUserDropdown && !authenticatedUser && (
             <AnonymousUserMenu />


### PR DESCRIPTION
## Summary
`LearningHelpSlot` (`org.openedx.frontend.layout.header_learning_help.v1`) already existed in `src/plugin-slots/LearningHelpSlot/index.jsx` but was never imported or rendered in `LearningHeader.jsx`, making it unavailable in the learning context.

This PR adds the missing import and renders `<LearningHelpSlot />` just before `<AuthenticatedUserDropdown />` inside the authenticated user block, matching the position used in the upstream header.

## Motivation
Required to unblock the RGG Gamification plugin (`frontend-rgg-widgets`), which injects its avatar/progress widget via `header_learning_help.v1`. Without this slot being rendered, the plugin has no anchor point in the learning header.

Closes #768

## Testing
This change should be validated by the **NAU team** by verifying that the RGG Gamification widget is injected and rendered correctly in the learning header when inside a course. 

Existing functionality (org logo, language selector) should remain unaffected.