### PR TITLE
chore(release): v20.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
Deploys the fixes in [PR #26](https://github.com/fccn/frontend-component-header-nau/pull/26) 

Adds the missing import and renders _LearningHelpSlot_ just before _AuthenticatedUserDropdown_ inside the authenticated user block, matching the position used in the upstream header.