### PR TITLE
fix: replace expiring npm token with `OIDC Trusted Publishers`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,14 @@ on:
     branches:
     - nau/*.master
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: read
-      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -43,4 +43,4 @@ jobs:
     - name: Build
       run: npm run build
     - name: Release to npmjs
-      run: npm publish
+      run: npx --yes npm@11 publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "20.1.0",
+  "version": "20.1.1",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
Closes fccn/nau-technical/issues/863

### Root cause

The Release CI originally used a Granular Access Token (`NPM_AUTH_TOKEN`) to publish to npm. Granular Access Tokens have a mandatory expiration date — once it expired, every publish attempt failed silently. A previous fix attempt added `permissions.id-token: write` at the **job level** with `environment: release`, but this still failed because: (1) permissions must be declared at the **workflow level** for GitHub's OIDC provider to issue tokens, and (2) bare `npm publish` requires npm 11+ to auto-detect and use OIDC credentials.

### What this PR changes

- Moves `permissions.id-token: write` and `contents: read` to the workflow level, where GitHub's OIDC token issuance actually operates.
- Removes `environment: release`, which was unused and caused the job to wait for an environment that was never configured.
- Replaces `npm publish` with `npx --yes npm@11 publish` — npm 11+ is required for automatic OIDC detection; the Node 20 default (npm 10.x) does not support it.
- Bumps version to `20.1.1`.

This was validated end-to-end on a personal fork ([bra-i-am/frontend-component-header-nau](https://github.com/bra-i-am/frontend-component-header-nau)) before being applied here.

### Benefits over a token

- **Never expires** — no scheduled token rotation, no silent failures months later.
- **No secret to manage** — the `NPM_AUTH_TOKEN` secret can be removed from repository settings entirely.
- **Scoped to this workflow** — the trust relationship is bound to `fccn/frontend-component-header-nau` and `release.yml` specifically.

### Required before merging

A maintainer with npm admin access to `@nauedu/frontend-component-header` needs to configure the Trusted Publisher on [npmjs.com](https://www.npmjs.com):

1. Go to the package settings → **Trusted Publishers** tab.
2. Add a new publisher with:
   - **Owner:** `fccn`
   - **Repository:** `frontend-component-header-nau`
   - **Workflow:** `release.yml`
   - **Environment:** *(leave empty)*
3. Optionally set **Publishing access** to *"Require two-factor authentication and disallow tokens"* to enforce OIDC-only publishing going forward.

    <img width="1123" height="834" alt="image" src="https://github.com/user-attachments/assets/2db35b02-9c9b-4756-8f93-a9d442fdbc8d" />

### References

- [npm Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers)
- [GitHub community discussion on setup-node + OIDC interaction](https://github.com/orgs/community/discussions/176761)
