### PR TITLE
fix: install npm@11 globally for OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,5 +42,7 @@ jobs:
         fail_ci_if_error: false
     - name: Build
       run: npm run build
+    - name: Install npm@11
+      run: npm install -g npm@11
     - name: Release to npmjs
-      run: npx --yes npm@11 publish
+      run: npm publish


### PR DESCRIPTION
## Summary

Fixes the OIDC Trusted Publishers authentication failure in the Release CI workflow. npm@11 requires being the active binary in PATH to properly detect GitHub Actions OIDC environment variables.

## Problem

The release workflow was failing with `ENEEDAUTH` error despite having:
- ✅ `permissions.id-token: write` configured at workflow level
- ✅ Trusted Publisher configured on npmjs.com
- ✅ npm@11 specified via `npx --yes npm@11 publish`

The issue: npm invoked through `npx` doesn't properly detect the OIDC environment context needed for Trusted Publishers authentication.

## Solution

- Install npm@11 globally as a separate step
- Use `npm publish` with npm@11 as the active binary

This ensures npm correctly detects `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables and performs automatic OIDC token exchange.

## Related

- Refs: fccn/nau-technical#863
- Related to fccn/frontend-component-header-nau#39