### PR TITLE
fix: downgrade to setup-node@v4 for OIDC Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Nodejs Env
       run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VER }}
     - name: Install dependencies
@@ -36,13 +36,11 @@ jobs:
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
     - name: Build
       run: npm run build
-    - name: Install npm@11
-      run: npm install -g npm@11
     - name: Release to npmjs
-      run: npm publish
+      run: npx --yes npm@11 publish


### PR DESCRIPTION
## Summary

- Downgrade `setup-node` from `v6` → `v4`
- Downgrade `codecov-action` from `v6` → `v4`
- Replace `npm install -g npm@11 && npm publish` with `npx --yes npm@11 publish`

## Root cause

`setup-node@v6` interferes with OIDC Trusted Publishers authentication, causing `ENEEDAUTH` even with `permissions.id-token: write` set at the workflow level and a correctly configured Trusted Publisher on npmjs.com.

`setup-node@v4` does not exhibit this issue. bra-i-am validated this exact configuration on their fork ([run 28671442485](https://github.com/bra-i-am/frontend-component-header-nau/actions/runs/28671442485)) and published successfully with provenance via OIDC.

## Refs

- Refs: fccn/nau-technical#863
- Related to fccn/frontend-component-header-nau#39
- Related to fccn/frontend-component-header-nau#40